### PR TITLE
ROR-17 Fix Saving Repair

### DIFF
--- a/pages/api/gateways/SaveRepairGateway.js
+++ b/pages/api/gateways/SaveRepairGateway.js
@@ -5,7 +5,8 @@ module.exports = makePostRequest => {
 
     result = await makePostRequest({
       uri: '/repair',
-      body
+      body,
+      headers: {'Content-Type': 'application/json'},
     }).then(response => {
       return response.data;
     });

--- a/pages/api/gateways/apiRequester.js
+++ b/pages/api/gateways/apiRequester.js
@@ -18,7 +18,7 @@ module.exports = axios => {
         })
     },
 
-    makePostRequest: ({uri, body ={}}) =>{
+    makePostRequest: ({uri, body ={}, headers}) =>{
       var identifier = process.env.REPAIRS_API_IDENTIFIER
       var baseUrl = process.env.REPAIRS_API_BASE_URL;
       const axiosInstance = axios.create({
@@ -28,7 +28,11 @@ module.exports = axios => {
         .then(response => {
           var jwt = response.data;
           axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${jwt}`;
-          return axiosInstance.post(uri, body);
+          if (headers){
+            return axiosInstance.post(uri, body, {headers: headers});
+          } else {
+            return axiosInstance.post(uri, body);
+          }
         })
     }
   }

--- a/tests/unit/gateways/SaveRepairGateway.test.js
+++ b/tests/unit/gateways/SaveRepairGateway.test.js
@@ -29,7 +29,8 @@ describe('SaveRepairGateway', () => {
           repairLocation: repairLocation,
           repairProblem: repairProblem,
           locationId: locationId
-        }
+        },
+        headers: {'Content-Type': 'application/json'}
       }
     )
     expect(result).toEqual(dummyID)

--- a/tests/unit/gateways/apiRequester.test.js
+++ b/tests/unit/gateways/apiRequester.test.js
@@ -49,7 +49,7 @@ describe('apiRequester', () => {
 
     });
 
-    test('a post request is made with headers', async () => {
+    test('a post request is made with authorization headers', async () => {
       const body = {
         a: 1, b: 2
       }
@@ -60,6 +60,22 @@ describe('apiRequester', () => {
       expect(mockedAxiosInstance.defaults.headers.common['Authorization']).toEqual(`Bearer ${jwt}`);
 
       expect(mockedPost).toHaveBeenNthCalledWith(2, uri, body);
+    });
+
+    test('a post request is made with supplied headers', async () => {
+      const body = {
+        a: 1, b: 2
+      }
+      const headers = {
+        'foo':'bar'
+      }
+      await apiRequester.makePostRequest({uri, body, headers});
+
+      expect(mockedPost).toHaveBeenNthCalledWith(1, `/authentication?identifier=${api_identifier}`);
+
+      expect(mockedAxiosInstance.defaults.headers.common['Authorization']).toEqual(`Bearer ${jwt}`);
+
+      expect(mockedPost).toHaveBeenNthCalledWith(2, uri, body, {headers: headers});
     });
   });
 });


### PR DESCRIPTION
When saving a repair the API was responding with a HTTP status code of 415 Unsupported Media Type.

Passing the media type when [making requests](https://github.com/LBHackney-IT/housing-repairs-online-frontend/pull/9/files#diff-58d9c4c1b2b80c487e1dfcf00a3a9a1d724b9b5885190242dec522b28614b74eR9) solves the issue.

Given no specific changes were made in the web API controller area, I suspect the issue may have been caused by the upgrade to .Net 6.0.