### PR TITLE
Increase lambda timeout

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -14,6 +14,7 @@ functions:
   HousingRepairsOnlineFrontend:
     name: ${self:service}-${self:provider.stage}
     handler: lambda.handler
+    timeout: 30
     package:
       include:
         - lambda.js


### PR DESCRIPTION
This is because there are 3 apis which are called to retrieve addresses which exceeds the default lambda timeout of 6 seconds
Co-authored-by: bhavesh-patel <bhavesh.patel@madetech.com>