### PR TITLE
Reduce deploy size

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -27,7 +27,7 @@ functions:
         - '!node_modules/@next/swc-darwin-arm64'       
         - '!node_modules/@sentry/cli/sentry-cli'         
     environment:
-     REPAIRS_API_IDENTIFIER: ${ssm:/HousingRepairsOnlineApi/${self:provider.stage}/authentication-identifier}
+      REPAIRS_API_IDENTIFIER: ${ssm:/HousingRepairsOnlineApi/${self:provider.stage}/authentication-identifier}
       REPAIRS_API_BASE_URL: ${ssm:/HousingRepairsOnlineApi/${self:provider.stage}/repairs-api-base-url}
     role: lambdaExecutionRole
     events:

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,6 +8,7 @@ provider:
   versionFunctions: true
 
 package:
+  excludeDevDependencies: true
   individually: true
   patterns:
     - '!./**'

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,7 +8,9 @@ provider:
   versionFunctions: true
 
 package:
-  excludeDevDependencies: true
+  individually: true
+  patterns:
+    - '!./**'
 
 functions:
   HousingRepairsOnlineFrontend:
@@ -16,14 +18,16 @@ functions:
     handler: lambda.handler
     timeout: 30
     package:
-      include:
-        - lambda.js
-        - next.config.js
-        - build/_next/**
-        - public/**
-        - node_modules/**
+      patterns:
+        - 'lambda.js'
+        - 'next.config.js'
+        - 'build/_next/**'
+        - 'public/**'
+        - 'node_modules/**'
+        - '!node_modules/@next/swc-darwin-arm64'       
+        - '!node_modules/@sentry/cli/sentry-cli'         
     environment:
-      REPAIRS_API_IDENTIFIER: ${ssm:/HousingRepairsOnlineApi/${self:provider.stage}/authentication-identifier}
+     REPAIRS_API_IDENTIFIER: ${ssm:/HousingRepairsOnlineApi/${self:provider.stage}/authentication-identifier}
       REPAIRS_API_BASE_URL: ${ssm:/HousingRepairsOnlineApi/${self:provider.stage}/repairs-api-base-url}
     role: lambdaExecutionRole
     events:


### PR DESCRIPTION
Updated serverless.yml to 

1. Exclude large binaries:
  node_modules/@next/swc-darwin-arm64     33.5MB
  node_modules/@sentry/cli/sentry-cli             22.4MB

2. Replace the deprecated 'include' section with a 'patterns' section.
3. Added global package options to make the pattern exclusions work

These changes should reduce the size of the Lambda zip file so it can be successfully deployed.

After trying several combinations, the patterns are only taken into account when the packages are set to package the functions individually and the exclude pattern is set at the package level.  This made a configuration similar to the bonus calculator front end: 
[https://github.com/LBHackney-IT/bonuscalc-frontend/blob/4daf5263256479986a9bc32cc14b33e2be1601c3/serverless.yml#L35-L39](url)

reference: individual setting [https://www.serverless.com/framework/docs/providers/aws/guide/packaging#patterns](url)

