### PR TITLE
Change order of css/scss imports

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,5 @@
-import '../styles/globals.css'
 import '../styles/globals.scss'
+import '../styles/globals.css'
 import React from 'react';
 import App from 'next/app'
 import Header from '../compoments/header';


### PR DESCRIPTION
## Description

The styling recently broke somewhat due to adding the library `sass`. This library was required when updating the version of NextJs, so it couldn't be removed.

After investigation, the issue was due to the line `@import 'https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap';` not working because, in the output `.css` file, it wasn't at the top anymore. For some reason, this means it wouldn't import the fonts.

After trying many different approaches, I found that reordering the importing of `globals.css` and `globals.scss` in the file `_app.js` fixed the issue.