### PR TITLE
MR-617 - Added call to PropertyEligible endpoint to validate selected property

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
   'rules': {
     // suppress errors for missing 'import React' in files
     'react/react-in-jsx-scope': 'off',
-    'quotes': ['error', 'single'],
-    'linebreak-style': ["warning", "windows"]
+    'quotes': ['error', 'single']
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
   'rules': {
     // suppress errors for missing 'import React' in files
     'react/react-in-jsx-scope': 'off',
-    'quotes': ['error', 'single']
+    'quotes': ['error', 'single'],
+    'linebreak-style': ["warning", "windows"]
   }
 };

--- a/compoments/report-repair/address.js
+++ b/compoments/report-repair/address.js
@@ -13,7 +13,6 @@ const Address = ({ handleChange, values }) => {
   const [state, setState] = useState({ error: {}, value: 'null' });
   const [error, setError] = useState(null)
   const [data, setData] = useState(null)
-  const [validProperty, setValidProperty] = useState(false)
 
   useEffect(() => {
     axios.get(`/api/address?postcode=${values.postcode}`)
@@ -63,23 +62,21 @@ const Address = ({ handleChange, values }) => {
         },
       });
     } else {
-      axios.get(`/api/verifypropertyeligibility?propertyid=${state.value.locationId}`)
+      axios.get(`/api/propertyeligible?propertyId=${state.value.locationId}`)
       .then(res => {
-        console.log(res)
-        setValidProperty(res.data.propertyEligible)
-        Continue();
+        const isPropertyEligible = res.data.propertyEligible
+        Continue(isPropertyEligible);
       })
       .catch(err => {
         console.error(err)
-        setValidProperty(false)
         setError(err)
       })
     }
   }
 
-  const Continue = () => {
+  const Continue = (isPropertyEligible = false) => {
 
-    if (!validProperty) {
+    if (!isPropertyEligible) {
       return handleChange(name, {
         addressLine1: state.value.addressLine1,
         postCode: state.value.postCode,

--- a/compoments/report-repair/address.js
+++ b/compoments/report-repair/address.js
@@ -55,20 +55,6 @@ const Address = ({ handleChange, values }) => {
   const verifyPropertyEligibility = (e) => {
     e.preventDefault();
 
-    axios.get(`/api/verifypropertyeligibility?propertyid=${state.value.locationId}`)
-      .then(res => {
-        setValidProperty(res.PropertyEligible)
-        Continue();
-      })
-      .catch(err => {
-        console.error(err)
-        setValidProperty(false)
-        setError(err)
-      })
-  }
-
-  const Continue = () => {
-
     if (state.value === 'null') {
       return setState({
         error: {
@@ -76,7 +62,22 @@ const Address = ({ handleChange, values }) => {
           touched: true,
         },
       });
+    } else {
+      axios.get(`/api/verifypropertyeligibility?propertyid=${state.value.locationId}`)
+      .then(res => {
+        console.log(res)
+        setValidProperty(res.data.propertyEligible)
+        Continue();
+      })
+      .catch(err => {
+        console.error(err)
+        setValidProperty(false)
+        setError(err)
+      })
     }
+  }
+
+  const Continue = () => {
 
     if (!validProperty) {
       return handleChange(name, {

--- a/compoments/report-repair/not-eligible-invalid-property.js
+++ b/compoments/report-repair/not-eligible-invalid-property.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
-const NotEligibleInvalidProperty = ({property}) => {
+const NotEligibleInvalidProperty = () => {
 
   return (
     <div className="govuk-grid-row govuk-body-m">
       <div className="govuk-grid-column-two-thirds">
         <h1 className='govuk-heading-xl lbh-heading-h1'>Property not eligible</h1>
         <p>
-            Unfortunately it is not possible to raise a repair on Repairs Online for the property at this address: <strong>{property.address.addressLine1} - {property.address.postCode}</strong>.
+            Unfortunately it is not possible to raise a repair on Repairs Online for the property at this address.
         </p>
       </div>
     </div>

--- a/compoments/report-repair/not-eligible-invalid-property.js
+++ b/compoments/report-repair/not-eligible-invalid-property.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const NotEligibleInvalidProperty = ({property}) => {
+
+  return (
+    <div className="govuk-grid-row govuk-body-m">
+      <div className="govuk-grid-column-two-thirds">
+        <h1 className='govuk-heading-xl lbh-heading-h1'>Property not eligible</h1>
+        <p>
+            Unfortunately it is not possible to raise a repair on Repairs Online for the property at this address: <strong>{property.address.addressLine1} - {property.address.postCode}</strong>.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default NotEligibleInvalidProperty;

--- a/flow.js
+++ b/flow.js
@@ -292,7 +292,6 @@ class Flow {
     if (nextFlowStep) {
       if (Array.isArray(nextFlowStep)) {
         let condition
-        console.log('handleChange value', value)
         if(typeof value === 'object'){
           condition = nextFlowStep.find(o => o.condition === value.value)
         }else{

--- a/flow.js
+++ b/flow.js
@@ -23,7 +23,10 @@ class Flow {
         {condition: 'no', nextStep: 'postcode'}
       ]},
       'postcode': {prevStep: 'communal', nextStep: 'address'},
-      'address': {prevStep: 'postcode', nextStep: 'repair-location'},
+      'address': {prevStep: 'postcode', nextStep: [
+        {condition: 'validProperty', nextStep: 'repair-location'},
+        {condition: 'invalidProperty', nextStep: 'not-eligible-invalid-property'}
+      ]},
       'repair-location': { prevStep: 'address', nextStep: [
         {condition: 'kitchen', nextStep: 'repair-kitchen-problems'},
         {condition: 'bathroom', nextStep: 'repair-bathroom-problems'},
@@ -156,7 +159,7 @@ class Flow {
       },
       'repair-bedroom-lighting-problems': { prevStep: 'repair-bedroom-problems', nextStep: 'repair-description'},
       'repair-living-areas-lighting-problems': { prevStep: 'repair-living-areas-problems', nextStep: 'repair-description'},
-      'wall-floor-ceiling-problems': { prevStep: 'repair-location',    
+      'wall-floor-ceiling-problems': { prevStep: 'repair-location',
         nextStep: [
         {condition: 'floorTiles', nextStep: 'unable-to-book'},
         {condition: 'skirtingBoardArchitrave', nextStep: 'unable-to-book'},
@@ -167,7 +170,7 @@ class Flow {
         {condition: 'woodenFloorboards', nextStep: 'unable-to-book'},
         ]
       },
-      'repair-kitchen-cupboard-problems': { prevStep: 'repair-kitchen-problems', 
+      'repair-kitchen-cupboard-problems': { prevStep: 'repair-kitchen-problems',
         nextStep: [
           {condition: 'doorHangingOff', nextStep: 'repair-description'},
           {condition: 'doorMissing', nextStep: 'unable-to-book'},
@@ -289,6 +292,7 @@ class Flow {
     if (nextFlowStep) {
       if (Array.isArray(nextFlowStep)) {
         let condition
+        console.log('handleChange value', value)
         if(typeof value === 'object'){
           condition = nextFlowStep.find(o => o.condition === value.value)
         }else{

--- a/pages/api/gateways/PropertyEligibleGateway.js
+++ b/pages/api/gateways/PropertyEligibleGateway.js
@@ -1,0 +1,12 @@
+module.exports = makeGetRequest => {
+  return async propertyId => {
+    var result;
+    result = await makeGetRequest({
+      uri: `/propertyeligible?propertyId=${propertyId}`
+    }).then(response => {
+      return response.data;
+    });
+
+    return result;
+  }
+};

--- a/pages/api/gateways/index.js
+++ b/pages/api/gateways/index.js
@@ -16,11 +16,13 @@ const searchPropertiesGateway = require('./SearchPropertiesGateway')(apiRequeste
 const availableAppointmentsGateway = require('./AvailableAppointmentsGateway')(apiRequester.makeGetRequest);
 const saveRepairGateway = require('./SaveRepairGateway')(apiRequester.makePostRequest);
 const checkMaintenanceModeGateway = require('./CheckMaintenanceModeGateway')(apiRequester.makeGetRequest);
+const propertyEligibleGateway = require('./PropertyEligibleGateway')(apiRequester.makeGetRequest);
 
 module.exports = {
   searchPropertiesGateway,
   availableAppointmentsGateway,
   saveRepairGateway,
   checkMaintenanceModeGateway,
+  propertyEligibleGateway,
   sentryParams
 };

--- a/pages/api/propertyeligible/index.js
+++ b/pages/api/propertyeligible/index.js
@@ -1,0 +1,18 @@
+const Sentry = require('@sentry/node');
+
+const {propertyEligibleGateway, sentryParams} = require('../gateways');
+
+export default async function handler (req, res) {
+  Sentry.init(sentryParams);
+
+  try {
+    let results = await propertyEligibleGateway(req.query.propertyId);
+    res.status(200).json(results)
+
+  } catch (e) {
+    Sentry.captureException(e);
+    await Sentry.flush(2000);
+    let results = new Error('An error occurred while attempting to validate the property');
+    res.status(500).json(results)
+  }
+};

--- a/pages/report-repair/[route].js
+++ b/pages/report-repair/[route].js
@@ -181,8 +181,7 @@ function ReportRepair() {
       )
     case 'not-eligible-invalid-property':
       return (
-        <NotEligibleInvalidProperty
-          property={values}/>
+        <NotEligibleInvalidProperty/>
       )
     case 'unable-to-book':
       return (

--- a/pages/report-repair/[route].js
+++ b/pages/report-repair/[route].js
@@ -23,6 +23,7 @@ import ContactDetails from '../../compoments/report-repair/contact-details';
 import Confirmation from '../../compoments/report-repair/confirmation';
 import Error from '../../compoments/error';
 import NotEligibleNonEmergency from '../../compoments/report-repair/not-eligible-non-emergency';
+import NotEligibleInvalidProperty from '../../compoments/report-repair/not-eligible-invalid-property';
 import UnableToBook from '../../compoments/report-repair/unable-to-book';
 import {customerServicesTelephoneNumber} from '../../globals';
 
@@ -177,6 +178,11 @@ function ReportRepair() {
     case 'not-eligible-communal-repairs':
       return (
         <NotEligibleCommunalRepairs/>
+      )
+    case 'not-eligible-invalid-property':
+      return (
+        <NotEligibleInvalidProperty
+          property={values}/>
       )
     case 'unable-to-book':
       return (
@@ -621,6 +627,7 @@ export async function getStaticPaths() {
     {params: { route: 'not-eligible'} },
     {params: { route: 'not-eligible-non-emergency'} },
     {params: { route: 'not-eligible-communal-repairs'} },
+    {params: { route: 'not-eligible-invalid-property'} },
     {params: { route: 'unable-to-book'} },
     {params: { route: 'postcode'} },
     {params: { route: 'priority-list'} },

--- a/tests/cypress/integration/reportRepair/address.spec.js
+++ b/tests/cypress/integration/reportRepair/address.spec.js
@@ -1,4 +1,4 @@
-import {intercept_address_search, propertyEligibilityValidationMock} from '../../support/helpers';
+import {intercept_address_search, interceptPropertyEligibilityCheck} from '../../support/helpers';
 
 function setup_addresses_search(setup_addresses_API) {
   setup_addresses_API();
@@ -46,7 +46,7 @@ describe('address', () => {
 
     context('When a user selects an option', ()=>{
       it('repair location page is shown if the property is eligible',  () => {
-        propertyEligibilityValidationMock(true, "propertyEligibleTrue")
+        interceptPropertyEligibilityCheck(true)
 
         cy.get('select').select('1 Downing Street, London, SW1A 2AA')
         cy.get('button').click()
@@ -55,7 +55,7 @@ describe('address', () => {
       });
 
       it('ineligible property page is shown if the property is not eligible',  () => {
-        propertyEligibilityValidationMock(false, "propertyEligibleFalse")
+        interceptPropertyEligibilityCheck(false)
 
         cy.get('select').select('1 Downing Street, London, SW1A 2AA')
         cy.get('button').click()

--- a/tests/cypress/integration/reportRepair/address.spec.js
+++ b/tests/cypress/integration/reportRepair/address.spec.js
@@ -1,4 +1,4 @@
-import {intercept_address_search} from '../../support/helpers';
+import {intercept_address_search, propertyEligibilityValidationMock} from '../../support/helpers';
 
 function setup_addresses_search(setup_addresses_API) {
   setup_addresses_API();
@@ -7,18 +7,6 @@ function setup_addresses_search(setup_addresses_API) {
     cy.get('button').click();
   });
   cy.get('[data-cy=address]', { timeout: 10000 }).then(($loadedSection) => {});
-}
-
-function propertyEligibilityValidationMock(propertyEligible, identifier) {
-  const propertyEligibleResult = {
-    propertyEligible: propertyEligible,
-    reason: "Example Reason"
-  };
-
-  cy.intercept('GET', `http://localhost:3000/api/propertyeligible?propertyId=12341000`, {
-    statusCode: 200,
-    body: propertyEligibleResult
-  }).as(identifier);
 }
 
 describe('address', () => {

--- a/tests/cypress/integration/reportRepair/confirmation.spec.js
+++ b/tests/cypress/integration/reportRepair/confirmation.spec.js
@@ -3,7 +3,8 @@ import {
   intercept_availability_search,
   navigateToPageSelectRadioOptionAndContinue,
   navigateToPageTypeInputTextAndContinue,
-  intercept_save_repair
+  intercept_save_repair,
+  interceptPropertyEligibilityCheck
 } from '../../support/helpers';
 
 const address = '1 Downing Street, London, SW1A 2AA';
@@ -85,6 +86,7 @@ describe('confirmation', () => {
   before(() => {
     intercept_availability_search();
     intercept_address_search();
+    interceptPropertyEligibilityCheck(true);
     intercept_save_repair(repairID);
     completeJourney();
   });
@@ -112,6 +114,7 @@ describe('confirmation', () => {
     before(() => {
       intercept_availability_search();
       intercept_address_search();
+      interceptPropertyEligibilityCheck(true);
       intercept_save_repair(repairID);
       completeJourney(true);
     });

--- a/tests/cypress/integration/reportRepair/repairAvailability.spec.js
+++ b/tests/cypress/integration/reportRepair/repairAvailability.spec.js
@@ -1,4 +1,5 @@
 import {
+  interceptPropertyEligibilityCheck,
   intercept_address_search,
   intercept_availability_search,
   navigateToPageSelectRadioOptionAndContinue,
@@ -93,6 +94,7 @@ describe('repair availability', () => {
     before(() => {
       intercept_availability_search();
       intercept_address_search();
+      interceptPropertyEligibilityCheck(true);
       cy.visit('http://localhost:3000/report-repair/');
 
       navigateToPageSelectRadioOptionAndContinue({

--- a/tests/cypress/integration/reportRepair/summary.spec.js
+++ b/tests/cypress/integration/reportRepair/summary.spec.js
@@ -4,7 +4,8 @@ import {
   navigateToPageSelectRadioOptionAndContinue,
   navigateToPageTypeInputTextAndContinue,
   convertDateToDisplayDate,
-  continueOnPage
+  continueOnPage,
+  interceptPropertyEligibilityCheck
 } from '../../support/helpers';
 
 describe('summary', () => {
@@ -17,6 +18,7 @@ describe('summary', () => {
   beforeEach(() => {
     intercept_availability_search();
     intercept_address_search();
+    interceptPropertyEligibilityCheck(true)
     cy.visit('http://localhost:3000/report-repair/');
 
     navigateToPageSelectRadioOptionAndContinue({
@@ -115,7 +117,6 @@ describe('summary', () => {
         cy.get('select').select(newAddress);
         cy.get('button').click();
       });
-
       cy.get('[data-cy=repair-location]', {timeout: 10000}).then(() => {
         cy.get('button').click();
       });

--- a/tests/cypress/support/helpers.js
+++ b/tests/cypress/support/helpers.js
@@ -6,7 +6,7 @@ function intercept_address_search(
   postcode='SW1A 2AA',
   nullAddressLine1 = false,
   nullAddressLine2 = false,
-  locationId = 12341000
+  locationId = 47009990
 ) {
   const api_url = 'http://localhost:3000/api';
   const response = [];
@@ -16,7 +16,7 @@ function intercept_address_search(
       addressLine1: !nullAddressLine1 ? `${i+1} Downing Street` : undefined,
       addressLine2: !nullAddressLine2 ? 'London' : undefined,
       postCode: postcode,
-      locationId: locationId + i
+      locationId: locationId
     });
   }
   cy.intercept('GET', `${api_url}/address?*`, {
@@ -106,13 +106,15 @@ function intercept_check_maintenance_mode(enable, statusCode = 200) {
   }).as('maintenance');
 }
 
-function propertyEligibilityValidationMock(propertyEligible, identifier) {
+function interceptPropertyEligibilityCheck(propertyEligible) {
   const propertyEligibleResult = {
     propertyEligible: propertyEligible,
     reason: "Example Reason"
   };
 
-  cy.intercept('GET', `http://localhost:3000/api/propertyeligible?propertyId=12341000`, {
+  const identifier = propertyEligible ? "propertyEligibileTrue" : "propertyEligibileFalse"
+
+  cy.intercept('GET', `http://localhost:3000/api/propertyeligible?propertyId=47009990`, {
     statusCode: 200,
     body: propertyEligibleResult
   }).as(identifier);
@@ -128,5 +130,5 @@ export {
   continueOnPage,
   navigateToLocation,
   intercept_check_maintenance_mode,
-  propertyEligibilityValidationMock
+  interceptPropertyEligibilityCheck
 }

--- a/tests/cypress/support/helpers.js
+++ b/tests/cypress/support/helpers.js
@@ -106,6 +106,18 @@ function intercept_check_maintenance_mode(enable, statusCode = 200) {
   }).as('maintenance');
 }
 
+function propertyEligibilityValidationMock(propertyEligible, identifier) {
+  const propertyEligibleResult = {
+    propertyEligible: propertyEligible,
+    reason: "Example Reason"
+  };
+
+  cy.intercept('GET', `http://localhost:3000/api/propertyeligible?propertyId=12341000`, {
+    statusCode: 200,
+    body: propertyEligibleResult
+  }).as(identifier);
+}
+
 export {
   intercept_address_search,
   intercept_availability_search,
@@ -115,5 +127,6 @@ export {
   intercept_save_repair,
   continueOnPage,
   navigateToLocation,
-  intercept_check_maintenance_mode
+  intercept_check_maintenance_mode,
+  propertyEligibilityValidationMock
 }

--- a/tests/cypress/support/helpers.js
+++ b/tests/cypress/support/helpers.js
@@ -5,7 +5,8 @@ function intercept_address_search(
   numberOfResults = 2,
   postcode='SW1A 2AA',
   nullAddressLine1 = false,
-  nullAddressLine2 = false
+  nullAddressLine2 = false,
+  locationId = 12341000
 ) {
   const api_url = 'http://localhost:3000/api';
   const response = [];
@@ -14,7 +15,8 @@ function intercept_address_search(
     response.push({
       addressLine1: !nullAddressLine1 ? `${i+1} Downing Street` : undefined,
       addressLine2: !nullAddressLine2 ? 'London' : undefined,
-      postCode: postcode
+      postCode: postcode,
+      locationId: locationId + i
     });
   }
   cy.intercept('GET', `${api_url}/address?*`, {

--- a/tests/cypress/support/helpers.js
+++ b/tests/cypress/support/helpers.js
@@ -74,6 +74,7 @@ const convertDateToDisplayDate = (date) => {
 
 const navigateToLocation = () => {
   intercept_address_search();
+  interceptPropertyEligibilityCheck(true);
   cy.visit('http://localhost:3000/report-repair/');
 
   navigateToPageSelectRadioOptionAndContinue({

--- a/tests/cypress/support/helpers.js
+++ b/tests/cypress/support/helpers.js
@@ -113,7 +113,7 @@ function interceptPropertyEligibilityCheck(propertyEligible) {
     reason: "Example Reason"
   };
 
-  const identifier = propertyEligible ? "propertyEligibileTrue" : "propertyEligibileFalse"
+  const identifier = propertyEligible ? "propertyEligibleTrue" : "propertyEligibleFalse"
 
   cy.intercept('GET', `http://localhost:3000/api/propertyeligible?propertyId=47009990`, {
     statusCode: 200,


### PR DESCRIPTION
Added property validation step

- Created new NotEligibleInvalidProperty component and route
- Modified address.js to add a call to the new verifyPropertyEligibility endpoint added to HousingManagementSystemApi to check whether or not the property is eligible/valid.
- Modified flow.js to add two possible next steps to follow the address component. The next component shown will either be the original RepairsLocation component, if the property is valid, otherwise, if the property is invalid, the user will be shown the new NotEligibleInvalidProperty component (see screenshot).
- Added test in address.spec.js to verify that, should the property not be valid, the new "ineligible-property" page is shown.
- Modified other test files to include the intercept of the property eligibility endpoint API call

![image](https://user-images.githubusercontent.com/70756861/207020035-567a06f9-5957-4ccb-a809-c5c691070e9b.png)


