### PR TITLE
Enable wallTiles and woodenFloorboards to be raised

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -160,11 +160,11 @@ class Flow {
         nextStep: [
         {condition: 'floorTiles', nextStep: 'unable-to-book'},
         {condition: 'skirtingBoardArchitrave', nextStep: 'unable-to-book'},
-        {condition: 'wallTiles', nextStep: 'unable-to-book'},
+        {condition: 'wallTiles', nextStep: 'repair-description'},
         {condition: 'lightFitting', nextStep: 'repair-description'},
         {condition: 'plasteringCeiling', nextStep: 'repair-description'},
         {condition: 'plasteringWalls', nextStep: 'repair-description'},
-        {condition: 'woodenFloorboards', nextStep: 'unable-to-book'},
+        {condition: 'woodenFloorboards', nextStep: 'repair-description'},
         ]
       },
       'repair-kitchen-cupboard-problems': { prevStep: 'repair-kitchen-problems', 


### PR DESCRIPTION
[Ticket](https://hackney.atlassian.net/browse/MR-620?atlOrigin=eyJpIjoiZjYyYmNlNjk0MjFiNGUwMzkzMjRlZDllYTE2YmRiZTEiLCJwIjoiaiJ9)

## Summary of Changes

- Update wallTiles and woodenFloorboard options to enable them to be raised