### PR TITLE
MR-641 - Prevent same repair to be submitted again

### DIFF
--- a/compoments/button.js
+++ b/compoments/button.js
@@ -1,8 +1,13 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 
-export default function Button({onClick, children, preventDoubleClick = false }) {
+export default function Button({onClick, children, preventDoubleClick = false, repairSubmitted = false }) {
   const [disabled, setDisabled] = useState(false);
   const [buttonText, setButtonText] = useState(children);
+
+  useEffect(() => {
+    if (repairSubmitted) setDisabled(true);
+  }, [])
+
   const click = (e) => {
     if (preventDoubleClick) {
       setDisabled(true);

--- a/compoments/report-repair/summary.js
+++ b/compoments/report-repair/summary.js
@@ -2,7 +2,7 @@ import React, {useEffect, useState} from 'react';
 import SummaryList from '../summaryList';
 import Button from '../button';
 
-const Summary = ({values, getNextStepFromCondition, submit, goToStep}) => {
+const Summary = ({values, getNextStepFromCondition, submit, goToStep, repairSubmitted}) => {
   let [repairProblemLink, setRepairProblemLink] = useState('')
   let [repairProblemBestDescriptionLink, setRepairProblemBestDescriptionLink] = useState('')
 
@@ -44,11 +44,17 @@ const Summary = ({values, getNextStepFromCondition, submit, goToStep}) => {
 
           </div>
         </div>
-        <Button
-          preventDoubleClick={true}
-          onClick={()=>{
-            submit(values);
-          }}>Continue</Button>
+        {repairSubmitted ?
+          <Button
+            repairSubmitted={true}
+            onClick={() => console.log("The repair has already been successfully submitted.")}
+            >Repair Submitted</Button> :
+          <Button
+            preventDoubleClick={true}
+            onClick={() => {
+              submit(values);
+            }}>Continue</Button>
+        }
       </div>
     )}
     </>

--- a/pages/report-repair/[route].js
+++ b/pages/report-repair/[route].js
@@ -61,6 +61,7 @@ function ReportRepair() {
   const [confirmation, setConfirmation] = useState('');
   const [formError, setFormError] = useState();
   const [requestId, setRequestId] = useState();
+  const [repairSubmitted, setRepairSubmitted] = useState(false);
 
   const cleanPayload = (payload) => {
     delete payload.availability.appointmentSlotKey
@@ -82,11 +83,11 @@ function ReportRepair() {
         time: values.availability
       }),
     }).then(response =>{
-      console.log(response)
       if (response.ok) {
         setShowBack(false);
         router.push('confirmation');
         setConfirmation(values.contactDetails.value);
+        setRepairSubmitted(true)
         return response.text().then((text)=> {
           setRequestId(text);
         });
@@ -128,6 +129,7 @@ function ReportRepair() {
           goToStep={goToStep}
           submit={submit}
           values={values}
+          repairSubmitted={repairSubmitted}
         />
       )
     case 'confirmation':


### PR DESCRIPTION
Before this PR, a user could submit a repair by pressing the Continue button on the Summary page, which would trigger a request to the back end and generate a new WO. Then, they could press the browser's "Back" button to return to the Summary page, and submit the repair again. This would submit the repair once again, generate a new WO for the property, with the same repair details.

Changes:
- when the user submits the repair, if the repair is successfully submitted (`response.ok`), we set `repairSubmitted` (new state in `[route].js`) to `true` (alternatively, we could use localStorage here and set a `repairSubmitted` key to `true`)
- the `Summary` component receives `repairSubmitted` as a prop, and based on this it renders either the usual "Continue" button, or the "new" disabled button that says "Repair Submitted"
- the `Button` component has now a `useEffect`, which checks for the `repairSubmitted` prop (passed in by `Summary` in this case). If this is set to `true` the button will be disabled.

Manually tested this, submitted a repair, pressed Back arrow on the browser, and the user is unable to submit again (button disabled, says "Repair Submitted"). As mentioned above, we could use localStorage instead of state in `[route].js` but I think the result would be the same.

Note: At the end of the flow, there's an option to "report a new repair". I've manually tested this, and once this process is re-started, `repairSubmitted` in `[route].js` is reinitialized and set to `false`, so the user is able to report another repair "the proper way" and go through the flow again.