### PR TITLE
Add page title (dynamic)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
       - image: circleci/node:14
   test:
     docker:
-      - image: circleci/node:12.22-browsers
+      - image: circleci/node:14-browsers
 
 references:
   workspace_root: &workspace_root '~'

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -22,7 +22,7 @@ function MyApp({ Component, pageProps, err  }) {
   useEffect(redirectIfMaintenanceMode, [])
 
   useEffect(() => {
-    var path = window.location.pathname === "/" ? " index" :  window.location.pathname
+    var path = window.location.pathname === '/' ? ' index' :  window.location.pathname
     var pageTitle = path.replaceAll('-',' ').replaceAll('/',' - ')
     document.title = 'Housing Repairs' + pageTitle
   })

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,6 +21,12 @@ function MyApp({ Component, pageProps, err  }) {
 
   useEffect(redirectIfMaintenanceMode, [])
 
+  useEffect(() => {
+    var path = window.location.pathname === "/" ? " index" :  window.location.pathname
+    var pageTitle = path.replaceAll('-',' ').replaceAll('/',' - ')
+    document.title = 'Housing Repairs' + pageTitle
+  })
+
   let gtmToken = process.env.NEXT_PUBLIC_GTM_TOKEN_ID
 
   return <>


### PR DESCRIPTION
- Formerly, page title was not set so defaulted to the URL
- Set page title dynamically to "Housing Repairs" + whatever the path is, formatted nicely
- If no path, just title the page "Housing Repairs index"

Why? Google Analytics