### PR TITLE
remove feedback banner

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -41,7 +41,7 @@ function MyApp({ Component, pageProps, err  }) {
     </Script>
     <Header/>
     <main className="govuk-main-wrapper govuk-!-padding-0">
-        <Component {...pageProps} err={err} />
+      <Component {...pageProps} err={err} />
     </main>
     <footer className="govuk-footer" role="contentinfo">
       <div className="govuk-width-container">

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -40,19 +40,6 @@ function MyApp({ Component, pageProps, err  }) {
       `}
     </Script>
     <Header/>
-    <div className="govuk-width-container">
-      <div className="govuk-phase-banner lbh-phase-banner lbh-container">
-        <p className="govuk-phase-banner__content">
-          <strong className="govuk-tag govuk-phase-banner__content__tag lbh-tag">
-            Beta
-          </strong>
-          <span className="govuk-phase-banner__text">This is our new website design - it&apos;s work in progress.<a href="mailto:repairshub.feedback@hackney.gov.uk" title="Tell us what you think">Tell us what you think</a>, your feedback will help us to improve it.</span>
-        </p>
-      </div>
-      <main className="govuk-main-wrapper govuk-!-padding-0">
-        <Component {...pageProps} err={err} />
-      </main>
-    </div>
     <footer className="govuk-footer" role="contentinfo">
       <div className="govuk-width-container">
         <div className="govuk-footer__meta">

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -40,6 +40,9 @@ function MyApp({ Component, pageProps, err  }) {
       `}
     </Script>
     <Header/>
+    <main className="govuk-main-wrapper govuk-!-padding-0">
+        <Component {...pageProps} err={err} />
+    </main>
     <footer className="govuk-footer" role="contentinfo">
       <div className="govuk-width-container">
         <div className="govuk-footer__meta">

--- a/tests/cypress/integration/landingPage.spec.js
+++ b/tests/cypress/integration/landingPage.spec.js
@@ -9,10 +9,6 @@ describe('App', () => {
     cy.contains('Housing Repairs Online');
   });
 
-  it('displays correct phase banner', () => {
-    cy.contains('This is our new website design - it\'s work in progress');
-  });
-
   it('displays a start button', () => {
     cy.get('a').contains('Start now').should('have.attr', 'href', '/report-repair/priority-list');
   });


### PR DESCRIPTION
The Feedback link on Repairs Online is being used by residents to complain about their repairs rather than giving actual feedback on the service itself, so it would make sense to remove it since obviously contact with residents should be done through the Customer Services team and the Housing teams.

[Jira Ticket](https://hackney.atlassian.net/browse/HPT-156)