### PR TITLE
Fix Deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
       - setup_remote_docker
       - run:
           name: Install serverless CLI
-          command: sudo npm i -g serverless
+          command: sudo npm i -g serverless@3.38.0
       - run:
           name: Deploy application
           command: |
@@ -120,10 +120,10 @@ jobs:
 workflows:
   test-staging-deploy:
     jobs:
-      # - build-and-test:
-      #     filters:
-      #       branches:
-      #         ignore: main
+      - build-and-test:
+          filters:
+            branches:
+              ignore: main
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           # requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ workflows:
           #   - build-and-test
           filters:
             branches:
-              only: main
+              ignore: main
       - deploy-to-staging:
           requires:
             - assume-role-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,10 @@ executors:
       - image: circleci/python:3.7
   node:
     docker:
-      - image: circleci/node:14
+      - image: circleci/node:20
   test:
     docker:
-      - image: circleci/node:14-browsers
+      - image: circleci/node:20-browsers
 
 references:
   workspace_root: &workspace_root '~'
@@ -118,22 +118,22 @@ jobs:
 
 
 workflows:
-  # check-and-deploy-development:
-  #   jobs:
-  #     - build-and-test:
-  #         filters:
-  #           branches:
-  #             only: development
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         requires:
-  #           - build-and-test
-  #         filters:
-  #           branches:
-  #             only: development
-  #     - deploy-to-development:
-  #         requires:
-  #           - assume-role-development
+  test-staging-deploy:
+    jobs:
+      - build-and-test:
+          filters:
+            branches:
+              ignore: main
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: main
+      - deploy-to-staging:
+          requires:
+            - assume-role-staging
 
   check-and-deploy-staging-and-production:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,14 +120,14 @@ jobs:
 workflows:
   test-staging-deploy:
     jobs:
-      - build-and-test:
-          filters:
-            branches:
-              ignore: main
+      # - build-and-test:
+      #     filters:
+      #       branches:
+      #         ignore: main
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
-          requires:
-            - build-and-test
+          # requires:
+          #   - build-and-test
           filters:
             branches:
               only: main
@@ -137,14 +137,14 @@ workflows:
 
   check-and-deploy-staging-and-production:
     jobs:
-      - build-and-test
+      - build-and-test:
+          filters:
+            branches:
+              only: main
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:
             - build-and-test
-          filters:
-            branches:
-              only: main
       - deploy-to-staging:
           requires:
             - assume-role-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,22 +118,12 @@ jobs:
 
 
 workflows:
-  test-staging-deploy:
+  check:
     jobs:
       - build-and-test:
           filters:
             branches:
               ignore: main
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          # requires:
-          #   - build-and-test
-          filters:
-            branches:
-              ignore: main
-      - deploy-to-staging:
-          requires:
-            - assume-role-staging
 
   check-and-deploy-staging-and-production:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,10 @@ executors:
       - image: circleci/python:3.7
   node:
     docker:
-      - image: circleci/node:20
+      - image: circleci/node:14
   test:
     docker:
-      - image: circleci/node:20-browsers
+      - image: circleci/node:14-browsers
 
 references:
   workspace_root: &workspace_root '~'


### PR DESCRIPTION
The pipeline was failing because it was installing and trying to use Serverless V4, which requires a licence
- Pinned pipeline serverless version to latest V3 version
- Run `check` workflow on feature branches instead of `check-and-deploy-staging-and-production` for clarity