### PR TITLE
Fix env fetching from parameter store

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,6 +23,10 @@ const moduleExports = {
   images: {
     loader: 'default',
   },
+
+  env: {
+    NEXT_PUBLIC_GTM_TOKEN_ID: process.env.NEXT_PUBLIC_GTM_TOKEN_ID,
+  },
 };
 
 module.exports = withSentryConfig(moduleExports, {


### PR DESCRIPTION
Fix fetching the env var from SSM - was previously being overriden by the CircleCI hardcoded env var, making the CI configuration highly misleading

The `NEXT_PUBLIC_GTM_TOKEN_ID` has been deleted from the CircleCI environment variables

This will allow properly setting separate values for staging and production